### PR TITLE
Basic log feature

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"context"
+
+	gotime "github.com/s-frick/go-time-track/pkg"
+	"github.com/spf13/cobra"
+)
+
+var logCmd = &cobra.Command{
+	Use:   "log",
+	Short: "Print each recorded frame.",
+	Long:  "Print each recorded frame.",
+	Run: func(cmd *cobra.Command, args []string) {
+		var ctx context.Context
+		if logJson {
+			ctx = context.WithValue(cmd.Context(), gotime.ContextKeyLogType, gotime.JsonLog)
+		} else if logCsv {
+			ctx = context.WithValue(cmd.Context(), gotime.ContextKeyLogType, gotime.CsvLog)
+		} else {
+			ctx = context.WithValue(cmd.Context(), gotime.ContextKeyLogType, gotime.PrettyLog)
+		}
+		gotime.Log(ctx)
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,10 +6,16 @@ import (
 	"os"
 
 	homedir "github.com/mitchellh/go-homedir"
+	gotime "github.com/s-frick/go-time-track/pkg"
 	"github.com/spf13/cobra"
 )
 
-var at string
+var (
+	at        string
+	logJson   bool
+	logCsv    bool
+	logPretty bool = true
+)
 
 func init() {
 	// cobra.OnInitialize(initConfig)
@@ -17,6 +23,13 @@ func init() {
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(stopCmd)
 	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(logCmd)
+
+	logCmd.Flags().BoolVarP(&logJson, "json", "j", false, "Log in json format")
+	logCmd.Flags().BoolVarP(&logCsv, "csv", "c", false, "Log in csv format")
+	logCmd.Flags().BoolVar(&logPretty, "pretty", true, "Log in pretty format")
+	logCmd.MarkFlagsMutuallyExclusive("json", "csv", "pretty")
+
 	startCmd.Flags().StringVar(&at, "at", "", "Start the frame at a specific time. e.g. \"09:25\"")
 	stopCmd.Flags().StringVar(&at, "at", "", "Stop the frame at a specific time. e.g. \"09:25\"")
 
@@ -68,7 +81,7 @@ func ExecuteContext() {
 		os.Exit(1)
 	}
 	gotimeDir := fmt.Sprintf("%s/.gotime", home)
-	ctx := context.WithValue(context.Background(), "gotimeDir", gotimeDir)
+	ctx := context.WithValue(context.Background(), gotime.ContextKeyGoTimeDir, gotimeDir)
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/spf13/cobra v1.8.0
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a h1:RYfmiM0zluBJOiPDJseKLEN4BapJ42uSi9SZBQ2YyiA=
+github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/context.go
+++ b/pkg/context.go
@@ -1,0 +1,24 @@
+package gotime
+
+import "context"
+
+type contextKey string
+
+func (c contextKey) String() string {
+	return string(c)
+}
+
+var (
+	// gotime log args
+	ContextKeyLogType = contextKey("logType")
+	// gotime config
+	ContextKeyGoTimeDir = contextKey("gotimeDir")
+)
+
+func GetGoTimeDir(ctx context.Context) string {
+	return ctx.Value(ContextKeyGoTimeDir).(string)
+}
+
+func GetLogType(ctx context.Context) LogType {
+	return ctx.Value(ContextKeyLogType).(LogType)
+}

--- a/pkg/gotime.go
+++ b/pkg/gotime.go
@@ -15,8 +15,11 @@ import (
 )
 
 const (
-	truncToMinute = (1 * time.Minute)
-	dformat       = "15 h and 4 m"
+	truncToMinute  = (1 * time.Minute)
+	dformat        = "15 h and 4 m"
+	dateTimeFormat = "02.01.2006 15:04"
+	timeFormat     = "15:04"
+	dateFormat     = "02.01.2006"
 )
 
 var bigBang = time.Unix(0, 0).UTC()
@@ -57,7 +60,8 @@ type Frame struct {
 type Frames []Frame
 
 type Options struct {
-	At string
+	At      string
+	LogType LogType
 }
 
 type InternOption struct {
@@ -93,7 +97,7 @@ func fileExists(filename string) bool {
 }
 
 func readState(ctx context.Context) *GoTime {
-	home := ctx.Value("gotimeDir")
+	home := GetGoTimeDir(ctx)
 	stateFile := fmt.Sprintf("%s/state", home)
 	tagFile := fmt.Sprintf("%s/tags", home)
 
@@ -131,7 +135,7 @@ func readState(ctx context.Context) *GoTime {
 }
 
 func saveToFile(ctx context.Context, file string, v any) {
-	home := ctx.Value("gotimeDir").(string)
+	home := GetGoTimeDir(ctx)
 	path := fmt.Sprintf("%s/%s", home, file)
 
 	stateJson, err := json.Marshal(v)
@@ -159,7 +163,7 @@ func saveToFile(ctx context.Context, file string, v any) {
 }
 
 func removeState(ctx context.Context) {
-	home := ctx.Value("gotimeDir")
+	home := GetGoTimeDir(ctx)
 	path := fmt.Sprintf("%s/%s", home, "state")
 	err := os.Remove(path)
 	if err != nil {
@@ -262,8 +266,8 @@ func (g *GoTime) stop(ctx context.Context, opt InternOption) Frame {
 	return f
 }
 
-func saveFrame(ctx context.Context, f Frame) {
-	home := ctx.Value("gotimeDir")
+func readFrames(ctx context.Context) Frames {
+	home := GetGoTimeDir(ctx)
 	framesFile := fmt.Sprintf("%s/frames", home)
 
 	rawFrames, err := os.ReadFile(framesFile)
@@ -277,7 +281,10 @@ func saveFrame(ctx context.Context, f Frame) {
 		frames = make([]Frame, 0)
 	}
 
-	frames = append(frames, f)
+	return frames
+}
 
-	saveToFile(ctx, "frames", frames)
+func saveFrame(ctx context.Context, f Frame) {
+	frames := readFrames(ctx)
+	saveToFile(ctx, "frames", append(frames, f))
 }

--- a/pkg/internal/color/color.go
+++ b/pkg/internal/color/color.go
@@ -13,7 +13,7 @@ var (
 	blue   = "\033[34m"
 	purple = "\033[35m"
 	cyan   = "\033[36m"
-	gray   = "\033[37m"
+	gray   = "\033[90m"
 	white  = "\033[97m"
 )
 
@@ -54,6 +54,7 @@ func (c Colorizer) Sprintf(format string, a ...any) string {
 	cFormat := fmt.Sprintf("%s%s%s", c.color, format, reset)
 	return fmt.Sprintf(cFormat, a...)
 }
+
 func (c Colorizer) Sprintln(a ...any) string {
 	strings := fmt.Sprintf("%s%s%s", c.color, fmt.Sprint(a...), reset)
 	return fmt.Sprintln(strings)
@@ -63,6 +64,7 @@ func (c Colorizer) Printf(format string, a ...any) (n int, err error) {
 	cFormat := fmt.Sprintf("%s%s%s", c.color, format, reset)
 	return fmt.Printf(cFormat, a...)
 }
+
 func (c Colorizer) Sprint(a ...any) string {
 	strings := fmt.Sprintf("%s%s%s", c.color, fmt.Sprint(a...), reset)
 	return fmt.Sprint(strings)
@@ -71,24 +73,31 @@ func (c Colorizer) Sprint(a ...any) string {
 func Red() TermColor {
 	return Colorizer{color: red}
 }
+
 func Green() TermColor {
 	return Colorizer{color: green}
 }
+
 func Yellow() TermColor {
 	return Colorizer{color: yellow}
 }
+
 func Blue() TermColor {
 	return Colorizer{color: blue}
 }
+
 func Purple() TermColor {
 	return Colorizer{color: purple}
 }
+
 func Cyan() TermColor {
 	return Colorizer{color: cyan}
 }
+
 func Gray() TermColor {
 	return Colorizer{color: gray}
 }
+
 func White() TermColor {
 	return Colorizer{color: white}
 }

--- a/pkg/log.go
+++ b/pkg/log.go
@@ -1,0 +1,157 @@
+package gotime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gocarina/gocsv"
+	"github.com/s-frick/go-time-track/pkg/internal/color"
+)
+
+type JsonLogFrame struct {
+	Start    time.Time `json:"start"`
+	End      time.Time `json:"end"`
+	ID       ID        `json:"id"`
+	Tags     []Tag     `json:"tags"`
+	Duration float64   `json:"duration"`
+}
+
+func NewJsonLogFrame(frame Frame) *JsonLogFrame {
+	stats := stats(frame)
+
+	d := time.Duration.Seconds(time.Duration(stats.duration))
+	return &JsonLogFrame{
+		Start:    frame.Start,
+		End:      frame.End,
+		ID:       frame.ID,
+		Tags:     frame.Tags,
+		Duration: d,
+	}
+}
+
+type CsvLogFrame struct {
+	Start    time.Time `csv:"start"`
+	End      time.Time `csv:"end"`
+	ID       ID        `csv:"id"`
+	Tags     string    `csv:"tags"`
+	Duration float64   `csv:"duration"`
+}
+
+func NewCsvLogFrame(frame Frame) *CsvLogFrame {
+	stats := stats(frame)
+
+	var sb strings.Builder
+	for i, tag := range frame.Tags {
+		sb.WriteString(string(tag))
+		if i != len(frame.Tags)-1 {
+			sb.WriteString(" ")
+		}
+	}
+
+	d := time.Duration.Seconds(time.Duration(stats.duration))
+	return &CsvLogFrame{
+		Start:    frame.Start,
+		End:      frame.End,
+		ID:       frame.ID,
+		Tags:     sb.String(),
+		Duration: d,
+	}
+}
+
+type LogType int
+
+const (
+	PrettyLog LogType = iota
+	JsonLog
+	CsvLog
+)
+
+func Log(ctx context.Context) {
+	frames := readFrames(ctx)
+
+	switch GetLogType(ctx) {
+	case PrettyLog:
+		prettyLog(frames)
+	case JsonLog:
+		jsonLog(frames)
+	case CsvLog:
+		csvLog(frames)
+	}
+}
+
+func jsonLog(frames Frames) {
+	for _, frame := range frames {
+		out := NewJsonLogFrame(frame)
+
+		stateJson, err := json.Marshal(out)
+		if err != nil {
+			log.Fatalf("Failed writing json log, %s", err)
+		}
+
+		_, err = os.Stdout.Write(stateJson)
+		os.Stdout.WriteString("\n")
+		if err != nil {
+			log.Fatalf("Failed writing json log, %s", err)
+		}
+	}
+}
+
+func csvLog(frames Frames) {
+	fs := make([]*CsvLogFrame, 0)
+	for _, frame := range frames {
+		fs = append(fs, NewCsvLogFrame(frame))
+	}
+
+	err := gocsv.MarshalFile(fs, os.Stdout)
+	if err != nil {
+		log.Fatalf("Failed writing csv log, %s", err)
+	}
+}
+
+func writePrettyFrameSet(cur time.Time, sum time.Duration, log string) {
+	fmt.Printf("\n%s%s%s%s\n", strings.Repeat(color.Red().Sprint("_"), 12), color.Red().Sprint("[ ", cur.Format(dateFormat), " ]"), strings.Repeat(color.Red().Sprint("_"), 12), color.Red().Sprint("[ ", sum.String(), " ]"))
+	fmt.Print(log)
+}
+
+func prettyLog(frames Frames) {
+	cur := bigBang
+	var log strings.Builder
+	sum := time.Duration(0)
+	for i, frame := range frames {
+		if cur.Equal(bigBang) {
+			cur = frame.Start.Truncate(24 * time.Hour)
+		}
+
+		if cur != frame.Start.Truncate(24*time.Hour) {
+			writePrettyFrameSet(cur, sum, log.String())
+
+			cur = bigBang
+			log.Reset()
+			sum = time.Duration(0)
+		}
+
+		stats := stats(frame)
+		start := frame.Start.Format(timeFormat)
+		end := frame.End.Format(timeFormat)
+
+		log.WriteString(color.Gray().Sprintf("  (%s)", frame.ID[:7]))
+		log.WriteString("      " + color.Purple().Sprint(start))
+		log.WriteString("  ~>  ")
+		log.WriteString(color.Purple().Sprint(end) + "    ")
+		log.WriteString(stats.duration.String())
+		log.WriteString(fmt.Sprintf("    %s", frame.Tags))
+		log.WriteString("\n")
+
+		sum = sum + time.Duration(stats.duration)
+
+		if i == len(frames)-1 {
+			writePrettyFrameSet(cur, sum, log.String())
+			fmt.Println()
+		}
+	}
+}


### PR DESCRIPTION
Log feature now has basic functionality to display all captured frames. You can display them as PrettyLog(default), JsonLog or CsvLog.


Print each recorded frame.

Usage:
  gotime log [flags]

Flags:
  -c, --csv      Log in csv format
  -h, --help     help for log
  -j, --json     Log in json format
      --pretty   Log in pretty format (default true)
